### PR TITLE
縦スクロールの処理を無効化

### DIFF
--- a/Sources/FluidStack/Helper/ScrollView+Handling.swift
+++ b/Sources/FluidStack/Helper/ScrollView+Handling.swift
@@ -84,10 +84,7 @@ final class ScrollController {
     debugPrint("\(timestamp): handleScrollViewEvent")
     // 垂直方向のスクロール（y座標の変更）を無視する
     // TODO: メッセージ画面で参照されているので縦方向のスクロールが発生した時に無限ループになってしまうため、このような対応を入れたが、本来は検知回数を少なくする対応が望ましい。
-    if oldValue.y != scrollView.contentOffset.y {
-      isHandlingEvent = false
-      return
-    }
+
 
     guard isLocking else {
       isHandlingEvent = false

--- a/Sources/FluidStack/Helper/ScrollView+Handling.swift
+++ b/Sources/FluidStack/Helper/ScrollView+Handling.swift
@@ -105,7 +105,7 @@ final class ScrollController {
     }
 
     previousValue = scrollView.contentOffset
-
+    debugPrint("\(timestamp): handleScrollViewEvent - setContentOffset")
     scrollView.setContentOffset(oldValue, animated: false)
 
     isHandlingEvent = false

--- a/Sources/FluidStack/Helper/ScrollView+Handling.swift
+++ b/Sources/FluidStack/Helper/ScrollView+Handling.swift
@@ -84,7 +84,10 @@ final class ScrollController {
     debugPrint("\(timestamp): handleScrollViewEvent")
     // 垂直方向のスクロール（y座標の変更）を無視する
     // TODO: メッセージ画面で参照されているので縦方向のスクロールが発生した時に無限ループになってしまうため、このような対応を入れたが、本来は検知回数を少なくする対応が望ましい。
-
+    if oldValue.y != scrollView.contentOffset.y {
+      isHandlingEvent = false
+      return
+    }
 
     guard isLocking else {
       isHandlingEvent = false

--- a/Sources/FluidStack/Helper/ScrollView+Handling.swift
+++ b/Sources/FluidStack/Helper/ScrollView+Handling.swift
@@ -78,6 +78,13 @@ final class ScrollController {
       return
     }
 
+    // 垂直方向のスクロール（y座標の変更）を無視する
+    // TODO: メッセージ画面で参照されているので縦方向のスクロールが発生した時に無限ループになってしまうため、このような対応を入れたが、本来は検知回数を少なくする対応が望ましい。
+    if oldValue.y != scrollView.contentOffset.y {
+      isHandlingEvent = false
+      return
+    }
+
     guard isLocking else {
       isHandlingEvent = false
       return

--- a/Sources/FluidStack/Helper/ScrollView+Handling.swift
+++ b/Sources/FluidStack/Helper/ScrollView+Handling.swift
@@ -78,6 +78,10 @@ final class ScrollController {
       return
     }
 
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+    let timestamp = dateFormatter.string(from: Date())
+    debugPrint("\(timestamp): handleScrollViewEvent")
     // 垂直方向のスクロール（y座標の変更）を無視する
     // TODO: メッセージ画面で参照されているので縦方向のスクロールが発生した時に無限ループになってしまうため、このような対応を入れたが、本来は検知回数を少なくする対応が望ましい。
     if oldValue.y != scrollView.contentOffset.y {

--- a/Sources/FluidStack/Helper/ScrollView+Handling.swift
+++ b/Sources/FluidStack/Helper/ScrollView+Handling.swift
@@ -78,10 +78,6 @@ final class ScrollController {
       return
     }
 
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
-    let timestamp = dateFormatter.string(from: Date())
-    debugPrint("\(timestamp): handleScrollViewEvent")
     // 垂直方向のスクロール（y座標の変更）を無視する
     // TODO: メッセージ画面で参照されているので縦方向のスクロールが発生した時に無限ループになってしまうため、このような対応を入れたが、本来は検知回数を少なくする対応が望ましい。
     if oldValue.y != scrollView.contentOffset.y {
@@ -105,7 +101,7 @@ final class ScrollController {
     }
 
     previousValue = scrollView.contentOffset
-    debugPrint("\(timestamp): handleScrollViewEvent - setContentOffset")
+
     scrollView.setContentOffset(oldValue, animated: false)
 
     isHandlingEvent = false


### PR DESCRIPTION
# OverView
- Room内で縦スクロールをした際に処理が無限ループしてしまう

![image](https://github.com/LinQTeam/FluidInterfaceKit/assets/9211010/fbbac58d-0e2f-48cb-a90d-23822bca7756)

- そもそものつくりでまずい点
  - FluidViewControllerのスクロール検知処理が無限ループする処理になっている
- 仕様上まずい点
  - Room内でスクロールしてる時にひたすら検知してしまって無限ループが発生しやすい状態になってしまっている
 
# Detail
- 縦スクロールを無効化した
- 本来無効化すべき内容でなさそうだが、Room内の仕様上どうしてもクラッシュしてしまうのでこちらの仕様にした
- これによってた縦スワイプの処理が消えてしまうがそもそもRoom内でしか使っていなさそうなのでユーザー体験上致命的ではない